### PR TITLE
Prevent transition style leak to the dragImage

### DIFF
--- a/DragDropTouch.js
+++ b/DragDropTouch.js
@@ -356,7 +356,7 @@ var DragDropTouch;
             var cs = getComputedStyle(src);
             for (var i = 0; i < cs.length; i++) {
                 var key = cs[i];
-                dst.style[key] = cs[key];
+                if(key.indexOf("transition") < 0) dst.style[key] = cs[key];
             }
             dst.style.pointerEvents = 'none';
             // and repeat for all children


### PR DESCRIPTION
First, thanks a lot for this library 👍 .

I noticed an issue, when you drag an element (on mobile) which has the css transition property set, it leaks to the generated "dragImage" (which is a dom copy of the dragged node).

The problem with this is that the image animation becomes completely erratic.

Steps to reproduce : 
   - http://bernardo-castilho.github.io/DragDropTouch/demo/index.htm
   - edit the `.column` css class to add the property `transition: all 1s;`
   - try to drag with touch events (for instance on chrome mobile view)

Proposed fix : prevent style copy for css properties containing the string `transition` (for vendor prefixes ...).

