### PR TITLE
Allow target element to cancel drag in dragstart

### DIFF
--- a/DragDropTouch.js
+++ b/DragDropTouch.js
@@ -223,7 +223,11 @@ var DragDropTouch;
                 }
                 // start dragging
                 if (this._dragSource && !this._img && this._shouldStartDragging(e)) {
-                    this._dispatchEvent(e, 'dragstart', this._dragSource);
+                    if (this._dispatchEvent(e, 'dragstart', this._dragSource)) {
+                        // target canceled the drag event
+                        this._dragSource = null;
+                        return;
+                    }
                     this._createImage(e);
                     this._dispatchEvent(e, 'dragenter', target);
                 }


### PR DESCRIPTION
If the target element calls preventDefault(), the drag operation should
be canceled. This matches the behavior of Firefox, Edge, Chrome, etc.