### PR TITLE
Use initial touch location for dragstart event

### DIFF
--- a/DragDropTouch.js
+++ b/DragDropTouch.js
@@ -223,7 +223,7 @@ var DragDropTouch;
                 }
                 // start dragging
                 if (this._dragSource && !this._img && this._shouldStartDragging(e)) {
-                    if (this._dispatchEvent(e, 'dragstart', this._dragSource)) {
+                    if (this._dispatchEvent(this._lastTouch, 'dragstart', this._dragSource)) {
                         // target canceled the drag event
                         this._dragSource = null;
                         return;

--- a/DragDropTouch.js
+++ b/DragDropTouch.js
@@ -223,7 +223,11 @@ var DragDropTouch;
                 }
                 // start dragging
                 if (this._dragSource && !this._img && this._shouldStartDragging(e)) {
-                    this._dispatchEvent(e, 'dragstart', this._dragSource);
+                    if (this._dispatchEvent(e, 'dragstart', this._dragSource)) {
+                        // target canceled the drag event
+                        this._dragSource = null;
+                        return;
+                    }
                     this._createImage(e);
                     this._dispatchEvent(e, 'dragenter', target);
                 }


### PR DESCRIPTION
The location of the dragstart event should be the location of the
initial mousedown event, as that's where the drag "originates" from.
Using the touchmove location could be different from the mousedown
location. Indeed, it could even be _outside_ the dragstart element.

The dragenter event still uses the current, touchmove location.

(This change is built on PR #50 and intended to be merged after that one.)