### PR TITLE
feat(event): add clientX/Y and layerX/Y to dispatch event

### DIFF
--- a/DragDropTouch.js
+++ b/DragDropTouch.js
@@ -411,6 +411,20 @@ var DragDropTouch;
                 this._copyStyle(src.children[i], dst.children[i]);
             }
         };
+        // compute missing offset or layer property for an event
+        DragDropTouch.prototype._setOffsetAndLayerProps = function (e, target) {
+            var rect = undefined;
+            if (e.offsetX === undefined) {
+                rect = target.getBoundingClientRect();
+                e.offsetX = e.clientX - rect.x;
+                e.offsetY = e.clientY - rect.y;
+            }
+            if (e.layerX === undefined) {
+                rect = rect || target.getBoundingClientRect();
+                e.layerX = e.pageX - rect.left;
+                e.layerY = e.pageY - rect.top;
+            }
+        }
         DragDropTouch.prototype._dispatchEvent = function (e, type, target) {
             if (e && target) {
                 var evt = document.createEvent('Event'), t = e.touches ? e.touches[0] : e;
@@ -419,6 +433,7 @@ var DragDropTouch;
                 evt.which = evt.buttons = 1;
                 this._copyProps(evt, e, DragDropTouch._kbdProps);
                 this._copyProps(evt, t, DragDropTouch._ptProps);
+                this._setOffsetAndLayerProps(evt, target);
                 evt.dataTransfer = this._dataTransfer;
                 target.dispatchEvent(evt);
                 return evt.defaultPrevented;


### PR DESCRIPTION
These changes follow the discussion #48 about using the script with React Grid Layout.
They allow to pass properties used by that other library.

Computation may be adjusted/rework, but it fixed my need, so maybe some other could save some time, I saw later that #55 also was about that missing properties.

For those who try to use the library with React Grid Layout, you may need also to remove pointer events from some elements, for example using:

```css
.react-grid-placeholder {
    pointer-events: none;
}
```