### PR TITLE
Typescript conversion of the dragdroptouch

### DIFF
--- a/ts/drag-drop-touch-util.ts
+++ b/ts/drag-drop-touch-util.ts
@@ -1,0 +1,108 @@
+// detect passive event support
+// https://github.com/Modernizr/Modernizr/issues/1894
+export function supportsPassive(dragRoot: {addEventListener: (...any: any[]) => any }) {
+  let supports = false;
+  try {
+    dragRoot.addEventListener('test', function () {
+    }, {
+      get passive() {
+        supports = true;
+        return true;
+      }
+    });
+  } catch {
+  }
+  return supports
+}
+
+
+export function pointFrom(e: TouchEvent, page = false) {
+  const touch = e.touches[0];
+  return {x: page ? touch.pageX : touch.clientX, y: page ? touch.pageY : touch.clientY};
+}
+
+
+
+export function copyProps(dst: Record<string, any>, src: Record<string, any>, props: Array<string>) {
+  for (let i = 0; i < props.length; i++) {
+    let p = props[i];
+    dst[p] = src[p];
+  }
+}
+
+
+export function newForwardableEvent(
+  type: keyof GlobalEventHandlersEventMap,
+  srcEvent: TouchEvent,
+  target: HTMLElement) {
+  const _kbdProps = ['altKey', 'ctrlKey', 'metaKey', 'shiftKey'];
+  const _ptProps = ['pageX', 'pageY', 'clientX', 'clientY', 'screenX', 'screenY', 'offsetX', 'offsetY'];
+  const evt =
+      new Event(type, {bubbles: true, cancelable: true}) as
+        unknown as
+        Mutable<MouseEvent, 'button' | 'which' | 'buttons'> & { readonly defaultPrevented: boolean },
+    touch = srcEvent.touches[0]
+  evt.button = 0;
+  evt.which = evt.buttons = 1;
+  copyProps(evt, srcEvent, _kbdProps);
+  copyProps(evt, touch, _ptProps);
+  setOffsetAndLayerProps(evt, target);
+  return evt;
+}
+
+
+
+function setOffsetAndLayerProps(e: Mutable<MouseEvent, `${'client' | 'layer' | 'offset' | 'page'}${'X' | 'Y'}`>, target: HTMLElement) {
+  const rect = target.getBoundingClientRect();
+  if (e.offsetX === undefined) {
+    e.offsetX = e.clientX - rect.x;
+    e.offsetY = e.clientY - rect.y;
+  }
+  if (e.layerX === undefined) {
+    e.layerX = e.pageX - rect.left;
+    e.layerY = e.pageY - rect.top;
+  }
+}
+
+
+export function copyStyle(src: HTMLElement, dst: HTMLElement) {
+  // remove potentially troublesome attributes
+  removeTroublesomeAttributes(dst);
+
+  // copy canvas content
+  if (src instanceof HTMLCanvasElement) {
+    let cDst = dst as HTMLCanvasElement;
+    cDst.width = src.width;
+    cDst.height = src.height;
+    cDst.getContext('2d')!.drawImage(src, 0, 0);
+  }
+
+  // copy style (without transitions)
+  copyComputedStyles(src, dst, k => k.indexOf('transition') < 0);
+  dst.style.pointerEvents = 'none';
+
+  // and repeat for all children
+  for (let i = 0; i < src.children.length; i++) {
+    copyStyle(src.children[i] as HTMLElement, dst.children[i] as HTMLElement);
+  }
+}
+
+
+function copyComputedStyles(src: any, dst: any, copyKey?: (k: string) => boolean) {
+  let cs = getComputedStyle(src);
+  for (let key in cs)
+    if (!copyKey || copyKey(key))
+      dst.style[key] = cs[key];
+}
+
+function removeTroublesomeAttributes(dst: any) {
+  ['id', 'class', 'style', 'draggable'].forEach(function (att) {
+    dst.removeAttribute(att);
+  });
+}
+
+
+
+type Mutable<T extends { [x: string]: any }, K extends string> = {
+  -readonly [P in (keyof T | K)]: T[P]
+}

--- a/ts/drag-drop-touch.ts
+++ b/ts/drag-drop-touch.ts
@@ -1,0 +1,345 @@
+//https://github.com/Bernardo-Castilho/dragdroptouch/blob/master/DragDropTouch.js
+'use strict';
+
+import {copyStyle, newForwardableEvent, pointFrom, supportsPassive} from "./drag-drop-touch-util";
+import {DragDTO} from "./drag-dto";
+
+const DefaultConfiguration = {
+  dragImageOpacity: '0.5',
+  dragThresholdPixels: 5,
+  isPressHoldMode: false,
+
+  contextMenuDelayMS: 900,
+  pressHoldDelayMS: 400,
+  pressHoldMargin: 25,
+  pressHoldThresholdPixels: 0,
+
+} as const;
+
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+/**
+ * Defines a class that adds support for touch-based HTML5 drag/drop operations.
+ *
+ * The @see:DragDropTouch class listens to touch events and raises the
+ * appropriate HTML5 drag/drop events as if the events had been caused
+ * by mouse actions.
+ *
+ * The purpose of this class is to enable using existing, standard HTML5
+ * drag/drop code on mobile devices running IOS or Android.
+ *
+ * To use, include the DragDropTouch.js file on the page. The class will
+ * automatically start monitoring touch events and will raise the HTML5
+ * drag drop events (`dragstart`, `dragenter`, `dragleave`, `drop`, `dragend`) which
+ * should be handled by the application.
+ *
+ * For details and examples on HTML drag and drop, see
+ * https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Drag_operations.
+ */
+export class DragDropTouch {
+
+  private readonly _dragRoot: Document | Element;
+  private _dropRoot: Document | ShadowRoot;
+  private _dragSource: EventTarget | null;
+  private _lastTouch: TouchEvent | null;
+  private _lastTarget: EventTarget | null;
+  private _ptDown: Point | null;
+  private _isDragEnabled: boolean;
+  private _isDropZone: boolean;
+  private _dataTransfer: DragDTO;
+  private _img: HTMLElement | null;
+  private _imgCustom: HTMLElement | null;
+  private _imgOffset: Point;
+  private _pressHoldIntervalId?: number | NodeJS.Timeout;
+
+  private readonly configuration: typeof DefaultConfiguration;
+
+
+  constructor(dragRoot: Document | Element = document, dropTree: Document | Element = document, options?: Partial<typeof DefaultConfiguration>) {
+    this._dragRoot = dragRoot;
+
+    this.configuration = {...DefaultConfiguration, ...(options || {})}
+
+    // Deal with shadow DOM elements.
+    // Previous implementation used `document.elementFromPoint` to find the dropped upon
+    // element. This, however, doesn't "pierce" the shadow DOM. So instead, we can
+    // provide a drop tree element to search within. It would be nice if `elementFromPoint`
+    // were implemented on this node (arbitrarily), but it only appears on documents and
+    // shadow roots. So here we simply walk up the DOM tree until we find that method.
+    // In fact this does NOT restrict dropping to just the root provided-- but the
+    // whole tree. I'm not sure that this is a general solution, but works for my specific
+    // and the general one.
+    this._dropRoot = dropTree as any
+    while (!(this._dropRoot as any).elementFromPoint && this._dropRoot.parentNode)
+      this._dropRoot = this._dropRoot.parentNode as any
+    this._dragSource = null;
+    this._lastTouch = null;
+    this._lastTarget = null;
+    this._ptDown = null;
+    this._isDragEnabled = false;
+    this._isDropZone = false;
+    this._dataTransfer = new DragDTO(this);
+    this._img = null;
+    this._imgCustom = null;
+    this._imgOffset = {x: 0, y: 0};
+    // this._pressHoldIntervalId = null;
+    this.listen();
+  }
+
+
+  listen() {
+    if (!navigator.maxTouchPoints) return
+
+    const opt = supportsPassive(this._dragRoot)
+      ? {passive: false, capture: false}
+      : false;
+
+    this._dragRoot.addEventListener('touchstart', this._touchstart.bind(this) as EventListener, opt);
+    this._dragRoot.addEventListener('touchmove', this._touchmove.bind(this) as EventListener, opt);
+    this._dragRoot.addEventListener('touchend', this._touchend.bind(this) as EventListener);
+    this._dragRoot.addEventListener('touchcancel', this._touchend.bind(this) as EventListener);
+  }
+
+
+  setDragImage(img: HTMLElement, offsetX: number, offsetY: number) {
+    this._imgCustom = img;
+    this._imgOffset = {x: offsetX, y: offsetY};
+  }
+
+  _touchstart(e: TouchEvent) {
+
+    if (this._shouldHandle(e)) {
+      this._reset();
+      let src = this._closestDraggable(e.target as Node);
+      if (src) {
+        // give caller a chance to handle the hover/move events
+        if (e.target &&
+          !this._dispatchEvent(e, 'mousemove', e.target) &&
+          !this._dispatchEvent(e, 'mousedown', e.target!)) {
+          // get ready to start dragging
+          this._dragSource = src;
+          this._ptDown = pointFrom(e);
+          this._lastTouch = e;
+
+          // do not prevent default (so input elements keep working)
+          //e.preventDefault();
+
+          // show context menu if the user hasn't started dragging after a while
+          setTimeout(() => {
+            if (this._dragSource === src && this._img === null) {
+              if (this._dispatchEvent(e, 'contextmenu', src)) {
+                this._reset();
+              }
+            }
+          }, this.configuration.contextMenuDelayMS);
+          if (this.configuration.isPressHoldMode) {
+            this._pressHoldIntervalId = setTimeout(() => {
+              this._isDragEnabled = true;
+              this._touchmove(e);
+            }, this.configuration.pressHoldDelayMS);
+          }
+        }
+      }
+    }
+  }
+
+  _touchmove(e: TouchEvent) {
+
+    if (this._shouldCancelPressHoldMove(e)) {
+      this._reset();
+      return;
+    }
+    if (this._shouldHandleMove(e) || this._shouldHandlePressHoldMove(e)) {
+
+      // see if target wants to handle move
+      let target = this._getTarget(e)!;
+      if (this._dispatchEvent(e, 'mousemove', target)) {
+        this._lastTouch = e;
+        e.preventDefault();
+        return;
+      }
+
+      // start dragging
+      if (this._dragSource && !this._img && this._shouldStartDragging(e)) {
+        if (this._dispatchEvent(this._lastTouch!, 'dragstart', this._dragSource)) {
+          // target canceled the drag event
+          this._dragSource = null;
+          return;
+        }
+        this._createImage(e);
+        this._dispatchEvent(e, 'dragenter', target);
+      }
+
+      // continue dragging
+      if (this._img && this._dragSource) {
+        this._lastTouch = e;
+        e.preventDefault(); // prevent scrolling
+        this._dispatchEvent(e, 'drag', this._dragSource);
+        if (target !== this._lastTarget) {
+          if (this._lastTarget)
+            this._dispatchEvent(this._lastTouch, 'dragleave', this._lastTarget);
+          this._dispatchEvent(e, 'dragenter', target);
+          this._lastTarget = target;
+        }
+        this._moveImage(e);
+        this._isDropZone = this._dispatchEvent(e, 'dragover', target)
+        //|| this._dispatchEvent(e, 'dragover', this._dragSource);
+      }
+    }
+  }
+
+  _touchend(e: TouchEvent) {
+    if (!(this._lastTouch && e.target && this._lastTarget)) return // TODO check this new logic
+
+    if (this._shouldHandle(e)) {
+      if (this._dispatchEvent(this._lastTouch, 'mouseup', e.target)) {
+        e.preventDefault();
+        return;
+      }
+
+      // user clicked the element but didn't drag, so clear the source and simulate a click
+      if (!this._img) {
+        this._dragSource = null;
+        this._dispatchEvent(this._lastTouch, 'click', e.target);
+      }
+
+      // finish dragging
+      this._destroyImage();
+      if (this._dragSource) {
+        if (e.type.indexOf('cancel') < 0 && this._isDropZone) {
+          this._dispatchEvent(this._lastTouch, 'drop', this._lastTarget);
+        }
+        this._dispatchEvent(this._lastTouch, 'dragend', this._dragSource);
+        this._reset();
+      }
+    }
+  }
+
+  _shouldHandle(e: TouchEvent) {
+    return e &&
+      !e.defaultPrevented &&
+      e.touches && e.touches.length < 2;
+  }
+
+  _shouldHandleMove(e: TouchEvent) {
+    return !this.configuration.isPressHoldMode && this._shouldHandle(e);
+  }
+
+  _shouldHandlePressHoldMove(e: TouchEvent) {
+    return this.configuration.isPressHoldMode &&
+      this._isDragEnabled && e && e.touches && e.touches.length;
+  }
+
+  _shouldCancelPressHoldMove(e: TouchEvent) {
+    return this.configuration.isPressHoldMode && !this._isDragEnabled &&
+      this._getDelta(e) > this.configuration.pressHoldMargin;
+  }
+
+  _shouldStartDragging(e: TouchEvent) {
+    let delta = this._getDelta(e);
+    return delta > this.configuration.dragThresholdPixels ||
+      (this.configuration.isPressHoldMode && delta >= this.configuration.pressHoldThresholdPixels);
+  }
+
+  _reset() {
+    this._destroyImage();
+    this._dragSource = null;
+    this._lastTouch = null;
+    this._lastTarget = null;
+    this._ptDown = null;
+    this._isDragEnabled = false;
+    this._isDropZone = false;
+    this._dataTransfer = new DragDTO(this);
+    clearInterval(this._pressHoldIntervalId);
+  }
+
+
+  _getDelta(e: TouchEvent) {
+    if (!this._ptDown) return 0; // Added by NDP  OK? TODO
+    if (this.configuration.isPressHoldMode && !this._ptDown) {
+      return 0;
+    }
+    let p = pointFrom(e);
+    return Math.abs(p.x - this._ptDown.x) + Math.abs(p.y - this._ptDown.y);
+  }
+
+  _getTarget(e: TouchEvent) {
+    let pt = pointFrom(e),
+      el = this._dropRoot.elementFromPoint(pt.x, pt.y);
+    while (el && getComputedStyle(el).pointerEvents == 'none') {
+      el = el.parentElement;
+    }
+    return el;
+  }
+
+  _createImage(e: TouchEvent) {
+    // just in case...
+    if (this._img) {
+      this._destroyImage();
+    }
+    // create drag image from custom element or drag source
+    let src = this._imgCustom || this._dragSource as HTMLElement;
+    this._img = src.cloneNode(true) as HTMLElement;
+    copyStyle(src, this._img);
+    this._img.style.top = this._img.style.left = '-9999px';
+    // if creating from drag source, apply offset and opacity
+    if (!this._imgCustom) {
+      let rc = src.getBoundingClientRect(),
+        pt = pointFrom(e);
+      this._imgOffset = {x: pt.x - rc.left, y: pt.y - rc.top};
+      this._img.style.opacity = this.configuration.dragImageOpacity;
+    }
+    // add image to document
+    this._moveImage(e);
+    document.body.appendChild(this._img);
+  }
+
+  _destroyImage() {
+    if (this._img && this._img.parentElement) {
+      this._img.parentElement.removeChild(this._img);
+    }
+    this._img = null;
+    this._imgCustom = null;
+  }
+
+  _moveImage(e: TouchEvent) {
+    requestAnimationFrame(() => {
+      if (this._img) {
+        let pt = pointFrom(e, true),
+          s = this._img.style;
+        s.position = 'absolute';
+        s.pointerEvents = 'none';
+        s.zIndex = '999999';
+        s.left = Math.round(pt.x - this._imgOffset.x) + 'px';
+        s.top = Math.round(pt.y - this._imgOffset.y) + 'px';
+      }
+    });
+  }
+  _dispatchEvent(srcEvent: TouchEvent, type: keyof GlobalEventHandlersEventMap, target: EventTarget) {
+
+    if (!(srcEvent && target))
+      return false;
+    const evt = newForwardableEvent(type, srcEvent, target as HTMLElement);
+
+    // DragEvents need a data transfer object
+    (evt as any).dataTransfer = this._dataTransfer;
+    target.dispatchEvent(evt as unknown as Event);
+    return evt.defaultPrevented;
+  }
+
+
+  _closestDraggable(el: Node | null) {
+    for (; el; el = el.parentElement) {
+      if (/*e.hasAttribute('draggable') &&*/ (el as any).draggable) {
+        return el;
+      }
+    }
+    return null;
+  }
+}
+
+dr

--- a/ts/drag-dto.ts
+++ b/ts/drag-dto.ts
@@ -1,0 +1,70 @@
+type DDT = {
+  setDragImage: (img: HTMLElement, offsetX: number, offsetY: number) => void
+}
+/**
+ * Object used to hold the data that is being dragged during drag and drop operations.
+ *
+ * It may hold one or more data items of different types. For more information about
+ * drag and drop operations and data transfer objects, see
+ * <a href="https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer">HTML Drag and Drop API</a>.
+ *
+ * This object is created automatically by the @see:DragDropTouch and is
+ * accessible through the @see:dataTransfer property of all drag events.
+ */
+export class DragDTO {
+  protected _dropEffect: any;
+  private _effectAllowed: any;
+  private _data: any;
+  private _dragDropTouch: any;
+  constructor(dragDropTouch: DDT) {
+    this._dropEffect = 'move';
+    this._effectAllowed = 'all';
+    this._data = {};
+    this._dragDropTouch = dragDropTouch
+  }
+
+  get dropEffect() {
+    return this._dropEffect;
+  }
+
+  set dropEffect(value) {
+    this._dropEffect = value;
+  }
+
+  get effectAllowed() {
+    return this._effectAllowed;
+  }
+
+  set effectAllowed(value) {
+    this._effectAllowed = value;
+  }
+
+  get types() {
+    return Object.keys(this._data);
+  }
+
+  clearData(type: string) {
+    if (type !== null) {
+      delete this._data[type.toLowerCase()];
+    } else {
+      this._data = {};
+    }
+  }
+
+  getData(type: string) {
+    let lcType = type.toLowerCase(),
+      data = this._data[lcType];
+    if (lcType === "text" && data == null) {
+      data = this._data["text/plain"]; // getData("text") also gets ("text/plain")
+    }
+    return data; // @see https://github.com/Bernardo-Castilho/dragdroptouch/pull/61/files
+  }
+
+  setData(type: string, value: any) {
+    this._data[type.toLowerCase()] = value;
+  }
+
+  setDragImage(img: Element, offsetX: number, offsetY: number) {
+    this._dragDropTouch.setDragImage(img, offsetX, offsetY)
+  }
+}


### PR DESCRIPTION
First, thank you for this project! It has saved me quite a bit of time and clarified what was going on for me .

I did this for a typescript project I have. I need to have sorting working on my Android tablet.

Obviously it should not be merged as is, as I just copied the files in from my project. I wanted to put it up there in case someone else was in a similar situation. I apologize if  you are trying to compare this to the Javascript version, as that will be mostly impossible. I changed things pretty freely to conform to my codebase, which is not normal PR behavior.

In addition to typescript:
- cleaned up a potential bugs revealed by the type checking-- nothing huge
- one approach at dealing with web components/shadow DOM
- some refactoring to pull out non-drag related utilities into their own files
- beginnings of "configuration" options. I didn't exercise these at all.
- removed the "singleton" nature of the code, and instead it's applied as needed. This is an aesthetic choice, but also necessitated by my approach to shadow DOM.

There's a `pressHoldMode`, but I didn't test this-- I wasn't clear how one might enable this in the original code if it was even possible, but it's configurable now.

Again, just putting this out there in case it's useful to someone. If you have question or comments, hit me up.